### PR TITLE
Bash: change prompt back to single-line (#20)

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -118,5 +118,5 @@ GIT_PS1_SHOWUPSTREAM="verbose git"
 # we don't want "command not found" errors when __git_ps1 is not installed
 type __git_ps1 &>/dev/null || function __git_ps1 () { true; }
 
-export PS1="${usercolor}\u@\h${pathcolor} \w${resetcolors}\$(__git_ps1)\n\\$ "
+export PS1="${usercolor}\u@\h${pathcolor} \w${resetcolors}\$(__git_ps1) "
 


### PR DESCRIPTION
There is a lot of controversy around this setting - I got votes for
keeping it and for deleting it as well. Since the point of sensible
dotfiles is to have a base common ground, I'm leaning towards abandoning
multi-line prompt.
