### PR TITLE
Add home path to osx compatibility file.

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -3,7 +3,7 @@
 
 
 # Load stuff specific to Macs if appropriate
-[ `uname` = Darwin ] && source .osx-compatibility.sh
+[ `uname` = Darwin ] && source $HOME/.osx-compatibility.sh
 
 # list directories before files (if installed version of ls allows this)
 if man ls | grep group-directories-first >&/dev/null; then


### PR DESCRIPTION
this prevents getting an error when sourcing .bashrc from anywhere